### PR TITLE
NodeList encapsulation

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1,3 +1,29 @@
+class CookCupNodeList {
+  constructor (nodeList) {
+    this.nodeList = nodeList
+  }
+
+  find () {
+    // Missing
+  }
+
+  first () {
+    return this.nodeList[0]
+  }
+
+  index (index) {
+    return this.nodeList[index]
+  }
+
+  last () {
+    return this.nodeList[this.nodeList.length - 1]
+  }
+
+  get elements() {
+    return this.nodeList
+  }
+}
+
 class CookCup {
   constructor (selector) {
     if (this === window) {
@@ -5,9 +31,8 @@ class CookCup {
     }
 
     const elements = document.querySelectorAll(selector)
-    elements.__proto__ = CookCup.methods
 
-    return elements
+    return new CookCupNodeList(elements)
   }
 
   static extends (object) {
@@ -48,24 +73,6 @@ class CookCup {
 
   static get version () {
     return '1.0.0'
-  }
-}
-
-CookCup.methods = {
-  find () {
-    // Missing.
-  },
-
-  first () {
-    return this[0]
-  },
-
-  index (index) {
-    return this[index]
-  },
-
-  last () {
-    return this[this.length - 1]
   }
 }
 


### PR DESCRIPTION
NodeList encapsulation

### What was a problem?

Original code was relying on __proto__ property, which has a serious performance penalty.

### How this "pull request" fixes the problem?

The proposed solution encapsulates a NodeList in a way that utility methods are still available without the performance penalty.

### Comments

The implementation uses CookCup as a simple factory when searching for selectors, which constructs a CookCupNodeList and return it as an object to the caller, hiding its implementation details and constructor. 
